### PR TITLE
Update Ruby templates to current RubyGem practices

### DIFF
--- a/templates/ruby/gemspec
+++ b/templates/ruby/gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir["lib/**/*"]
 
-  gem.add_dependency "faraday", ">= 0.9.0"
-  gem.add_dependency "json", ">= 1.7.7"
+  gem.add_dependency "faraday", "~> 0.9", ">= 0.9.0"
+  gem.add_dependency "json", "~> 1.7", ">= 1.7.7"
 end

--- a/templates/ruby/lib/http_client/response_handler.rb
+++ b/templates/ruby/lib/http_client/response_handler.rb
@@ -6,7 +6,7 @@ module {{call .Fnc.camelize .Pkg.Name}}
     class ResponseHandler
 
       def self.get_body(response)
-        type = response.response_headers["content-type"]
+        type = response.response["content-type"]
         body = response.body
 {{if .Api.Response.Formats.Json}}
         # Response body is in JSON

--- a/templates/ruby/lib/version.rb
+++ b/templates/ruby/lib/version.rb
@@ -1,0 +1,3 @@
+module {{call .Fnc.camelize .Pkg.Name}}
+  VERSION = "{{.Pkg.Version}}"
+end


### PR DESCRIPTION
Adding a version.rb

Open ended Ruby dependencies are no longer recommended by RubyGems: See http://guides.rubygems.org/specification-reference/
